### PR TITLE
fix(parsers): Add '%' to symbols grammar.

### DIFF
--- a/src/parsers/mod.rs
+++ b/src/parsers/mod.rs
@@ -15,6 +15,17 @@ mod test {
                         CreateZpoolRequestBuilder, Health, Reason, Zpool}};
 
     #[test]
+    fn test_issue_78_minimal() {
+        let line = "  scan: resilver in progress since Tue Aug 13 23:03:11 2019\n\t42.5K scanned at 42.5K/s, 80K issued at 80K/s, 83K total\n\t512 resilvered, 96.39% done, no estimated completion time\n";
+        let mut pairs = StdoutParser::parse(Rule::scan_line, line).unwrap_or_else(|e| panic!("{}", e));
+        let pair = pairs.next().unwrap();
+        let inner = pair.into_inner().next().unwrap().as_span();
+        let span = inner.as_str();
+        let expected = "resilver in progress since Tue Aug 13 23:03:11 2019\n\t42.5K scanned at 42.5K/s, 80K issued at 80K/s, 83K total\n\t512 resilvered, 96.39% done, no estimated completion time\n";
+        assert_eq!(expected, span);
+    }
+
+    #[test]
     fn test_action_single_line() {
         let one_line = " action: The pool can be imported using its name or numeric identifier.\n";
         parses_to! {

--- a/src/parsers/stdout.pest
+++ b/src/parsers/stdout.pest
@@ -3,7 +3,7 @@ whitespace = _{ " " | "\t" }
 digit = _{ '0'..'9' }
 digits =  { digit ~ (digit | "_")* }
 alpha = _{ 'a'..'z' | 'A'..'Z' }
-symbol = _{ "!" | "@" | "," | "." | ";" | ":" | "/" | "\'" | "\"" | "(" | ")" | "-" }
+symbol = _{ "!" | "@" | "," | "." | ";" | ":" | "/" | "\'" | "\"" | "(" | ")" | "-"  | "%" }
 alpha_num = _{ digit | alpha }
 alpha_nums = _{ alpha_num+ }
 text = _{ (alpha_num | whitespace |symbol)+ }
@@ -29,7 +29,7 @@ pool_line = { whitespace* ~ name ~ whitespace* ~ state_enum ~ whitespace? ~ erro
 raid_line = { whitespace* ~ raid_name ~ whitespace* ~ state_enum ~ whitespace? ~ error_statistics? ~ whitespace* ~ reason? ~ "\n"? }
 disk_line = { whitespace* ~ path ~ whitespace* ~ state_enum ~ whitespace? ~ error_statistics? ~ whitespace* ~ reason? ~ "\n"? }
 
-scan_line = { whitespace* ~ "scan:" ~ whitespace* ~ text_line }
+scan_line = { whitespace* ~ "scan:" ~ whitespace* ~ multi_line_text }
 pool_headers = _{ whitespace* ~ "NAME" ~ whitespace* ~ "STATE"  ~ whitespace* ~ "READ" ~ whitespace* ~ "WRITE" ~ whitespace* ~ "CKSUM" ~ "\n" }
 no_errors = { "No known data errors" }
 errors = { whitespace* ~ "errors:" ~ whitespace* ~ (no_errors | multi_line_text) }
@@ -47,4 +47,4 @@ zpools = _{ zpool*  ~ whitespace* }
 
 text_line = _{ text ~ "\n" }
 aligned_text_line = _{ (whitespace{8} | "\t") ~ text ~ "\n" }
-multi_line_text = { text_line ~ aligned_text_line{, 4} }
+multi_line_text = { text_line ~ aligned_text_line{, 5} }


### PR DESCRIPTION
Text with "%" wasn't matched as text and "scan" was expected to be single line at all times.

Closes #78 