### PR TITLE
fix(zfs): Fixed 'Failed to parse value: VariantNotFound' on Linux, zfs-2.0.3

### DIFF
--- a/src/zfs/properties.rs
+++ b/src/zfs/properties.rs
@@ -345,13 +345,13 @@ impl Default for Dedup {
 pub enum Normalization {
     #[strum(serialize = "none")]
     None,
-    #[strum(serialize = "formc")]
+    #[strum(serialize = "formc", serialize = "formC")]
     FormC,
-    #[strum(serialize = "formd")]
+    #[strum(serialize = "formd", serialize = "formD")]
     FormD,
-    #[strum(serialize = "formkc")]
+    #[strum(serialize = "formkc", serialize = "formKC")]
     FormKC,
-    #[strum(serialize = "formkd")]
+    #[strum(serialize = "formkd", serialize = "formKD")]
     FormKD,
 }
 


### PR DESCRIPTION
On Debian 10, zfs-2.0.3-8~bpo10+1, using ZfsOpen3::read_properties() on a pool throws the following error:

thread 'main' panicked at 'Failed to parse value: VariantNotFound', /home/candunc/.cargo/git/checkouts/libzetta-rs-e848604138a482a1/cf5649a/src/zfs/open3.rs:303:56

This is due to my zfs returning ```bpool   normalization   formD   -```, rather than the all-lowercase ```formd``` as defined in zfs::properties::Normalization enum. I have modified the enum to catch these camelCase variants.