### PR TITLE
feat(zfs): Convert nvlist errors to HashMaps to make the Error type Send+Sync (#152)

### DIFF
--- a/src/zfs/errors.rs
+++ b/src/zfs/errors.rs
@@ -1,7 +1,6 @@
 use crate::parsers::zfs::{Rule, ZfsParser};
-use libnv::nvpair::NvList;
 use pest::Parser;
-use std::{borrow::Cow, io, path::PathBuf};
+use std::{borrow::Cow, collections::HashMap, io, path::PathBuf};
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;
 pub type ValidationResult<T = (), E = ValidationError> = std::result::Result<T, E>;
@@ -28,7 +27,7 @@ quick_error! {
         ValidationErrors(errors: Vec<ValidationError>) {
             from()
         }
-        MultiOpError(err: NvList) {
+        MultiOpError(err: HashMap<String, libnv::nvpair::Value>) {
             from()
         }
         Unimplemented {}

--- a/src/zfs/lzc.rs
+++ b/src/zfs/lzc.rs
@@ -190,7 +190,7 @@ impl ZfsEngine for ZfsLzc {
         if !errors_list_ptr.is_null() {
             let errors = unsafe { NvList::from_ptr(errors_list_ptr) };
             if !errors.is_empty() {
-                return Err(Error::from(errors));
+                return Err(Error::from(errors.into_hashmap()));
             }
         }
         match errno {
@@ -225,7 +225,7 @@ impl ZfsEngine for ZfsLzc {
         if !errors_list_ptr.is_null() {
             let errors = unsafe { NvList::from_ptr(errors_list_ptr) };
             if !errors.is_empty() {
-                return Err(Error::from(errors));
+                return Err(Error::from(errors.into_hashmap()));
             }
         }
         match errno {
@@ -265,7 +265,7 @@ impl ZfsEngine for ZfsLzc {
         if !errors_list_ptr.is_null() {
             let errors = unsafe { NvList::from_ptr(errors_list_ptr) };
             if !errors.is_empty() {
-                return Err(Error::from(errors));
+                return Err(Error::from(errors.into_hashmap()));
             }
         }
         match errno {
@@ -301,7 +301,7 @@ impl ZfsEngine for ZfsLzc {
         if !errors_list_ptr.is_null() {
             let errors = unsafe { NvList::from_ptr(errors_list_ptr) };
             if !errors.is_empty() {
-                return Err(Error::from(errors));
+                return Err(Error::from(errors.into_hashmap()));
             }
         }
         match errno {


### PR DESCRIPTION
Fixes #152 by converting these to hashmaps