### PR TITLE
In CreateDatasetRequest, inherit most things if not explicitly set

### DIFF
--- a/src/zfs/lzc.rs
+++ b/src/zfs/lzc.rs
@@ -89,22 +89,40 @@ impl ZfsEngine for ZfsLzc {
         let name_c_string =
             CString::new(request.name().to_str().expect("Non UTF-8 name")).expect("NULL in name");
         // LZC wants _everything_ as u64 even booleans.
-        props.insert_u64(AclInheritMode::nv_key(), request.acl_inherit.as_nv_value())?;
+        if let Some(acl_inherit) = request.acl_inherit {
+            props.insert_u64(AclInheritMode::nv_key(), acl_inherit.as_nv_value())?;
+        }
         if let Some(acl_mode) = request.acl_mode {
             props.insert_u64(AclMode::nv_key(), acl_mode.as_nv_value())?;
         }
-        props.insert_u64("atime", bool_to_u64(request.atime))?;
-        props.insert_u64(Checksum::nv_key(), request.checksum.as_nv_value())?;
-        props.insert_u64(Compression::nv_key(), request.compression.as_nv_value())?;
-        props.insert_u64(Copies::nv_key(), request.copies().as_nv_value())?;
-        props.insert_u64("devices", bool_to_u64(request.devices))?;
-        props.insert_u64("exec", bool_to_u64(request.exec))?;
+        if let Some(atime) = request.atime {
+            props.insert_u64("atime", bool_to_u64(atime))?;
+        }
+        if let Some(checksum) = request.checksum {
+            props.insert_u64(Checksum::nv_key(), checksum.as_nv_value())?;
+        }
+        if let Some(compression) = request.compression {
+            props.insert_u64(Compression::nv_key(), compression.as_nv_value())?;
+        }
+        if let Some(copies) = request.copies() {
+            props.insert_u64(Copies::nv_key(), copies.as_nv_value())?;
+        }
+        if let Some(devices) = request.devices {
+            props.insert_u64("devices", bool_to_u64(devices))?;
+        }
+        if let Some(exec) = request.exec {
+            props.insert_u64("exec", bool_to_u64(exec))?;
+        }
         // saved fore mount point
-        props.insert_u64("primarycache", request.primary_cache.as_nv_value())?;
+        if let Some(primary_cache) = request.primary_cache {
+            props.insert_u64("primarycache", primary_cache.as_nv_value())?;
+        }
         if let Some(quota) = request.quota {
             props.insert_u64("quota", quota)?;
         }
-        props.insert_u64("readonly", bool_to_u64(request.readonly))?;
+        if let Some(readonly) = request.readonly {
+            props.insert_u64("readonly", bool_to_u64(readonly))?;
+        }
         if let Some(record_size) = request.record_size {
             props.insert_u64("recordsize", record_size)?;
         }
@@ -114,9 +132,15 @@ impl ZfsEngine for ZfsLzc {
         if let Some(ref_reservation) = request.ref_reservation {
             props.insert_u64("refreservation", ref_reservation)?;
         }
-        props.insert_u64("secondarycache", request.secondary_cache.as_nv_value())?;
-        props.insert_u64("setuid", bool_to_u64(request.setuid))?;
-        props.insert_u64(SnapDir::nv_key(), request.snap_dir.as_nv_value())?;
+        if let Some(secondary_cache) = request.secondary_cache {
+            props.insert_u64("secondarycache", secondary_cache.as_nv_value())?;
+        }
+        if let Some(setuid) = request.setuid {
+            props.insert_u64("setuid", bool_to_u64(setuid))?;
+        }
+        if let Some(snap_dir) = request.snap_dir {
+            props.insert_u64(SnapDir::nv_key(), snap_dir.as_nv_value())?;
+        }
 
         if request.kind == DatasetKind::Filesystem
             && (request.volume_size.is_some() || request.volume_block_size.is_some())
@@ -135,7 +159,9 @@ impl ZfsEngine for ZfsLzc {
             props.insert_u64("volblocksize", vol_block_size)?;
         }
 
-        props.insert("xattr", bool_to_u64(request.xattr))?;
+        if let Some(xattr) = request.xattr {
+            props.insert("xattr", bool_to_u64(xattr))?;
+        }
         if let Some(user_props) = request.user_properties() {
             for (key, value) in user_props {
                 props.insert_string(key, value)?;

--- a/src/zfs/mod.rs
+++ b/src/zfs/mod.rs
@@ -185,22 +185,22 @@ pub struct CreateDatasetRequest {
     // the rest is zfs native properties
     /// Controls how ACL entries inherited when files and directories created.
     #[builder(default)]
-    acl_inherit:       AclInheritMode,
+    acl_inherit:       Option<AclInheritMode>,
     /// Controls how an ACL entry modified during a `chmod` operation.
     #[builder(default)]
     acl_mode:          Option<AclMode>,
     /// Controls whether the access time for files updated when they are read.
-    #[builder(default = "true")]
-    atime:             bool,
+    #[builder(default)]
+    atime:             Option<bool>,
     /// Controls whether a file system can be mounted.
     #[builder(default)]
     can_mount:         CanMount,
     /// Controls the checksum used to verify data integrity.
     #[builder(default)]
-    checksum:          Checksum,
+    checksum:          Option<Checksum>,
     /// Enables or disables compression for a dataset.
     #[builder(default)]
-    compression:       Compression,
+    compression:       Option<Compression>,
     /// Sets the number of copies of user data per file system. Available values are 1, 2, or 3.
     /// These copies are in addition to any pool-level redundancy. Disk space used by multiple
     /// copies of user data charged to the corresponding file and dataset, and counts against
@@ -208,26 +208,26 @@ pub struct CreateDatasetRequest {
     /// enabled. Consider setting this property when the file system created because changing this
     /// property on an existing file system only affects newly written data.
     #[builder(default)]
-    copies:            Copies,
+    copies:            Option<Copies>,
     /// Controls whether device files in a file system can be opened.
-    #[builder(default = "true")]
-    devices:           bool,
+    #[builder(default)]
+    devices:           Option<bool>,
     /// Controls whether programs in a file system allowed to be executed. Also, when set to
     /// `false`, `mmap(2)` calls with `PROT_EXEC` disallowed.
-    #[builder(default = "true")]
-    exec:              bool,
+    #[builder(default)]
+    exec:              Option<bool>,
     /// Controls the mount point used for this file system.
     #[builder(default)]
     mount_point:       Option<PathBuf>,
     /// Controls what is cached in the primary cache (ARC).
     #[builder(default)]
-    primary_cache:     CacheMode,
+    primary_cache:     Option<CacheMode>,
     /// Limits the amount of disk space a dataset and its descendants can consume.
     #[builder(default)]
     quota:             Option<u64>,
     /// Controls whether a dataset can be modified.
-    #[builder(default = "false")]
-    readonly:          bool,
+    #[builder(default)]
+    readonly:          Option<bool>,
     /// Specifies a suggested block size for files in a file system in bytes. The size specified
     /// must be a power of two greater than or equal to 512 and less than or equal to 128 KiB.
     /// If the large_blocks feature is enabled on the pool, the size may be up to 1 MiB.
@@ -247,13 +247,13 @@ pub struct CreateDatasetRequest {
     reservation:       Option<u64>,
     /// Controls what is cached in the secondary cache (L2ARC).
     #[builder(default)]
-    secondary_cache:   CacheMode,
+    secondary_cache:   Option<CacheMode>,
     /// Controls whether the `setuid` bit is honored in a file system.
-    #[builder(default = "true")]
-    setuid:            bool,
+    #[builder(default)]
+    setuid:            Option<bool>,
     /// Controls whether the .zfs directory is hidden or visible in the root of the file system
     #[builder(default)]
-    snap_dir:          SnapDir,
+    snap_dir:          Option<SnapDir>,
     /// For volumes, specifies the logical size of the volume.
     #[builder(default)]
     volume_size:       Option<u64>,
@@ -264,8 +264,8 @@ pub struct CreateDatasetRequest {
     #[builder(default)]
     volume_block_size: Option<u64>,
     /// Indicates whether extended attributes are enabled or disabled.
-    #[builder(default = "true")]
-    xattr:             bool,
+    #[builder(default)]
+    xattr:             Option<bool>,
 }
 
 impl CreateDatasetRequest {


### PR DESCRIPTION
Without this change it's not really possible to create a dataset that inherits any of these properties.