### PR TITLE
ci(azure): Bump builders to 20.04

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,7 +13,7 @@ jobs:
         sudo apt-get install -y libblkid-dev libattr1-dev libcurl4-openssl-dev libelf-dev libdw-dev cmake gcc binutils-dev libiberty-dev zlib1g-dev libssl-dev
       displayName: Install dependencies
     - script: |
-        sudo sh -c "curl https://sh.rustup.rs -sSf | sh -y"
+        sudo sh -c "curl https://sh.rustup.rs -sSf | sh -s -- -y"
         sudo env PATH=${PATH} rustup install stable
     - script: |
         sudo apt-get update


### PR DESCRIPTION
Since recent ubuntu has ZOL "in base" there is no need to use ppa.