### PR TITLE
fix(zfs): filesystem_limit/snapshot_limit/filesystem_count/snapshot_count can now be 'none'

### DIFF
--- a/src/zfs/open3.rs
+++ b/src/zfs/open3.rs
@@ -267,10 +267,10 @@ pub(crate) fn parse_filesystem_lines(lines: &mut Lines, name: PathBuf) -> Proper
                 properties.exec(parse_bool(&value));
             },
             "filesystem_count" => {
-                properties.filesystem_count(value.parse().expect(FAILED_TO_PARSE));
+                properties.filesystem_count(parse_opt_num(&value));
             },
             "filesystem_limit" => {
-                properties.filesystem_limit(value.parse().expect(FAILED_TO_PARSE));
+                properties.filesystem_limit(parse_opt_num(&value));
             },
             "guid" => {
                 properties.guid(Some(value.parse().expect(FAILED_TO_PARSE)));
@@ -346,10 +346,10 @@ pub(crate) fn parse_filesystem_lines(lines: &mut Lines, name: PathBuf) -> Proper
                 properties.snap_dir(value.parse().expect(FAILED_TO_PARSE));
             },
             "snapshot_count" => {
-                properties.snapshot_count(value.parse().expect(FAILED_TO_PARSE));
+                properties.snapshot_count(parse_opt_num(&value));
             },
             "snapshot_limit" => {
-                properties.snapshot_limit(value.parse().expect(FAILED_TO_PARSE));
+                properties.snapshot_limit(parse_opt_num(&value));
             },
             "sync" => {
                 properties.sync(value.parse().expect(FAILED_TO_PARSE));
@@ -554,10 +554,10 @@ pub(crate) fn parse_volume_lines(lines: &mut Lines, name: PathBuf) -> Properties
                 properties.secondary_cache(value.parse().expect(FAILED_TO_PARSE));
             },
             "snapshot_count" => {
-                properties.snapshot_count(value.parse().expect(FAILED_TO_PARSE));
+                properties.snapshot_count(parse_opt_num(&value));
             },
             "snapshot_limit" => {
-                properties.snapshot_limit(value.parse().expect(FAILED_TO_PARSE));
+                properties.snapshot_limit(parse_opt_num(&value));
             },
             "sync" => {
                 properties.sync(value.parse().expect(FAILED_TO_PARSE));
@@ -625,6 +625,13 @@ fn parse_unknown_lines(lines: &mut Lines) -> Properties {
 
 fn parse_bool(val: &str) -> bool { val == "yes" || val == "on" }
 
+fn parse_opt_num(val: &str) -> Option<u64> {
+    match val {
+        "-" | "none" | "" => None,
+        _ => Some(val.parse().expect(FAILED_TO_PARSE)),
+    }
+}
+
 fn parse_mount_point(val: &str) -> Option<PathBuf> {
     match val {
         "-" | "none" => None,
@@ -686,8 +693,8 @@ mod test {
             .devices(true)
             .dnode_size(DnodeSize::Legacy)
             .exec(true)
-            .filesystem_count(0xFFFF_FFFF_FFFF_FFFF)
-            .filesystem_limit(0xFFFF_FFFF_FFFF_FFFF)
+            .filesystem_count(Some(0xFFFF_FFFF_FFFF_FFFF))
+            .filesystem_limit(Some(0xFFFF_FFFF_FFFF_FFFF))
             .guid(Some(10_533_576_440_524_459_469))
             .jailed(Some(false))
             .log_bias(LogBias::Latency)
@@ -711,8 +718,8 @@ mod test {
             .secondary_cache(CacheMode::All)
             .setuid(true)
             .snap_dir(SnapDir::Hidden)
-            .snapshot_count(0xFFFF_FFFF_FFFF_FFFF)
-            .snapshot_limit(0xFFFF_FFFF_FFFF_FFFF)
+            .snapshot_count(Some(0xFFFF_FFFF_FFFF_FFFF))
+            .snapshot_limit(Some(0xFFFF_FFFF_FFFF_FFFF))
             .sync(SyncMode::Standard)
             .used(102_563_762_176)
             .used_by_children(0)
@@ -761,8 +768,8 @@ mod test {
             .ref_reservation(70_871_154_688)
             .reservation(0)
             .secondary_cache(CacheMode::All)
-            .snapshot_count(0xFFFF_FFFF_FFFF_FFFF)
-            .snapshot_limit(0xFFFF_FFFF_FFFF_FFFF)
+            .snapshot_count(Some(0xFFFF_FFFF_FFFF_FFFF))
+            .snapshot_limit(Some(0xFFFF_FFFF_FFFF_FFFF))
             .sync(SyncMode::Standard)
             .used(73_652_740_096)
             .used_by_children(0)

--- a/src/zfs/properties.rs
+++ b/src/zfs/properties.rs
@@ -483,9 +483,9 @@ pub struct FilesystemProperties {
     /// The total number of filesystems that exist under this location in the dataset tree.  This
     /// value is only available when a filesystem_limit has been set somewhere in the tree under
     /// which the dataset resides.
-    filesystem_count:        u64,
+    filesystem_count:        Option<u64>,
     /// Limits the number of filesystems that can be created on a dataset and its descendents.
-    filesystem_limit:        u64,
+    filesystem_limit:        Option<u64>,
     /// GUID of the dataset
     #[builder(default)]
     guid:                    Option<u64>,
@@ -540,9 +540,9 @@ pub struct FilesystemProperties {
     /// The total number of snapshots that exist under this location in the dataset tree.  This
     /// value is only available when a snapshot_limit has been set somewhere in the tree under
     /// which the dataset resides.
-    snapshot_count:          u64,
+    snapshot_count:          Option<u64>,
     /// Limits the number of snapshots that can be created on a dataset and its descendents.
-    snapshot_limit:          u64,
+    snapshot_limit:          Option<u64>,
     /// Controls the behavior of synchronous requests.
     sync:                    SyncMode,
     /// Read-only property that identifies the amount of disk space consumed by a dataset and all
@@ -685,9 +685,9 @@ pub struct VolumeProperties {
     /// The total number of snapshots that exist under this location in the dataset tree.  This
     /// value is only available when a snapshot_limit has been set somewhere in the tree under
     /// which the dataset resides.
-    snapshot_count:          u64,
+    snapshot_count:          Option<u64>,
     /// Limits the number of snapshots that can be created on a dataset and its descendents.
-    snapshot_limit:          u64,
+    snapshot_limit:          Option<u64>,
     /// Controls the behavior of synchronous requests.
     sync:                    SyncMode,
     /// Read-only property that identifies the amount of disk space consumed by a dataset and all


### PR DESCRIPTION
On FreeBSD -CURRENT these properties are `none` by default now:

```
nvme/home  filesystem_limit      none                   default
nvme/home  snapshot_limit        none                   default
nvme/home  filesystem_count      none                   default
nvme/home  snapshot_count        none                   default
```

This was causing panics when parsing.