### PR TITLE
fix(zfs): Fix destroy_bookmarks method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ target*
 test-results/
 .direnv
 .vagrant
+libfuckery
+build.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ bitflags = "1.2.1"
 once_cell = "1.3.1"
 
 [dependencies.libnv]
-version = "0.2.3"
+version = "0.3.0"
 default-features = false
 features = ["nvpair"]
 
@@ -50,6 +50,9 @@ rand = "0.8"
 slog-term = "2"
 tempdir = "0.3"
 tempfile = "3"
+
+[build-dependencies]
+cmake = "0.1"
 
 [package.metadata.release]
 dev-version-ext = "pre"

--- a/flake.nix
+++ b/flake.nix
@@ -58,6 +58,7 @@
             vagrant
             just
             zlib
+            cmake
         ];
         PROJECT_ROOT = builtins.toString ./.;
         RUST_SRC_PATH = "${rust}/lib/rustlib/src/rust/library";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,3 +61,9 @@ const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 pub mod log;
 pub use log::GlobalLogger;
+
+pub mod fuckery {
+   extern {
+       pub(crate) fn fuckery_make_nvlist() -> *mut zfs_core_sys::nvlist_t;
+   }
+}

--- a/src/zfs/lzc.rs
+++ b/src/zfs/lzc.rs
@@ -324,7 +324,7 @@ impl ZfsEngine for ZfsLzc {
         let mut bookmarks_list = NvList::default();
 
         for bookmark in bookmarks {
-            bookmarks_list.insert(&bookmark.to_string_lossy(), true)?;
+            bookmarks_list.insert_boolean(&bookmark.to_string_lossy())?;
         }
 
         let mut errors_list_ptr = null_mut();

--- a/tests/test_zfs.rs
+++ b/tests/test_zfs.rs
@@ -284,11 +284,9 @@ fn easy_snapshot_and_bookmark() {
     zfs.destroy_snapshots(&expected_snapshots, DestroyTiming::RightNow).unwrap();
     assert_eq!(Ok(false), zfs.exists(expected_snapshots[0].clone()));
 
-    // TODO: Fix this method
-    // Still no clue what is wrong after entire day trying. GH Issue: 159
-    //zfs.destroy_bookmarks(&expected_bookmarks).unwrap();
-    //let bookmarks = zfs.list_bookmarks(root).expect("failed to list bookmarks");
-    //assert!(bookmarks.is_empty())
+    zfs.destroy_bookmarks(&expected_bookmarks).unwrap();
+    let bookmarks = zfs.list_bookmarks(root).expect("failed to list bookmarks");
+    assert!(bookmarks.is_empty())
 }
 
 #[test]


### PR DESCRIPTION
The issue was wrong type. Turns out `boolean` and `boolean_value` are not
the same thing and are not interchangeable. 

Closes #159