### PR TITLE
fix(zfs): Allow snapshotting of entire pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,8 @@ jobs:
         sudo losetup /dev/loop99 `pwd`/loop99
       displayName: Setup loop device
     - script: |
-        curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git andoriyu/cargo-suity
+        curl -LSfs https://japaric.github.io/trust/install.sh | sh -s -- --git andoriyu/cargo-suity --tag v0.3.0 
+        
         sudo ln -s /home/vsts/.cargo/bin/cargo-suity /usr/local/bin/
       displayName: Install suity
     - script: |

--- a/src/zfs/mod.rs
+++ b/src/zfs/mod.rs
@@ -313,7 +313,7 @@ pub(crate) mod validators {
         if name.ends_with('/') {
             return Err(ValidationError::MissingName(dataset.to_owned()));
         }
-        if dataset.has_root() || dataset.components().count() < 2 {
+        if dataset.has_root() {
             return Err(ValidationError::MissingPool(dataset.to_owned()));
         }
         dataset

--- a/tests/test_zfs.rs
+++ b/tests/test_zfs.rs
@@ -480,6 +480,7 @@ fn snapshot_entire_pool() {
     zfs.snapshot(&expected_snapshots, None).expect("Failed to create snapshots");
 
     let snapshots = zfs.list_snapshots(root.clone()).expect("failed to list snapshots");
+    dbg!(&snapshots);
     assert_eq!(expected_snapshots, snapshots);
     assert_eq!(Ok(true), zfs.exists(expected_snapshots[0].clone()));
 

--- a/tests/test_zfs.rs
+++ b/tests/test_zfs.rs
@@ -461,29 +461,3 @@ fn send_snapshot_incremental() {
 
     zfs.send_incremental(snapshot, src_snapshot, tmpfile, SendFlags::empty()).unwrap();
 }
-
-// Issue #172
-#[test]
-fn snapshot_entire_pool() {
-    let zpool = SHARED_ZPOOL.clone();
-    let zfs = DelegatingZfsEngine::new().expect("Failed to initialize ZfsLzc");
-    let root_name = get_dataset_name();
-    let root = PathBuf::from(format!("{}/{}", zpool, &root_name));
-    let request = CreateDatasetRequest::builder()
-        .name(root.clone())
-        .kind(DatasetKind::Filesystem)
-        .build()
-        .unwrap();
-    zfs.create(request).expect("Failed to create a root dataset");
-    let expected_snapshots = vec![PathBuf::from(format!("{}@whole-pool-snap-1", zpool))];
-
-    zfs.snapshot(&expected_snapshots, None).expect("Failed to create snapshots");
-
-    let snapshots = zfs.list_snapshots(root.clone()).expect("failed to list snapshots");
-    dbg!(&snapshots);
-    assert_eq!(expected_snapshots, snapshots);
-    assert_eq!(Ok(true), zfs.exists(expected_snapshots[0].clone()));
-
-    zfs.destroy_snapshots(&expected_snapshots, DestroyTiming::RightNow).unwrap();
-    assert_eq!(Ok(false), zfs.exists(expected_snapshots[0].clone()));
-}


### PR DESCRIPTION
Change validation rule to allow taking a snapshot of the entire pool.

Closes #172 