### PR TITLE
Add test for pool spare parsing and fix spares array being empty

### DIFF
--- a/src/parsers/stdout.pest
+++ b/src/parsers/stdout.pest
@@ -1,7 +1,7 @@
 whitespace = _{ " " | "\t" }
 
 digit = _{ '0'..'9' }
-digits =  { digit ~ (digit | "_")* }
+digits = { digit ~ (digit | "_")* }
 alpha = _{ 'a'..'z' | 'A'..'Z' }
 symbol = _{ "!" | "@" | "," | "." | ";" | ":" | "/" | "\'" | "\"" | "(" | ")" | "-"  | "%" }
 alpha_num = _{ digit | alpha }
@@ -9,7 +9,7 @@ alpha_nums = _{ alpha_num+ }
 text = _{ (alpha_num | whitespace |symbol)+ }
 path = @{ !raid_enum ~ "/"? ~ (name ~ "/"?)+ }
 url = @{ ("https" | "http") ~ ":/" ~ path }
-state_enum = { "ONLINE" | "OFFLINE" | "UNAVAIL" | "DEGRADED" | "FAULTED" | "AVAIL"}
+state_enum = { "ONLINE" | "OFFLINE" | "UNAVAIL" | "DEGRADED" | "FAULTED" | "AVAIL" | "INUSE" }
 raid_enum = { "mirror" | "raidz1" | "raidz2" | "raidz3" }
 raid_name = ${ raid_enum ~ ("-" ~ digits)? }
 name = @{ ("_" | "-" | "."| alpha_num)+ }

--- a/src/zpool/properties.rs
+++ b/src/zpool/properties.rs
@@ -48,6 +48,8 @@ pub enum Health {
     Unavailable,
     /// Physically removed while the system was running.
     Removed,
+    /// Spare has taken over for failed device.
+    Inuse,
 }
 
 impl Health {
@@ -63,6 +65,7 @@ impl Health {
             "AVAIL" => Ok(Health::Available),
             "UNAVAIL" => Ok(Health::Unavailable),
             "REMOVED" => Ok(Health::Removed),
+            "INUSE" => Ok(Health::Inuse),
             _ => Err(ZpoolError::ParseError),
         }
     }


### PR DESCRIPTION
Inuse spares are not listed in the spares field, so I've updated the grammar and corresponding `Health` enum to fix this. L517 tests that the spares array is no longer empty.

This test reveals two other bugs which I will likely have MRs for sometime in the future:
- `spare-0` is listed as a disk (grammar fix done, need some code tweaks) see L511
- the faulted drive lists 0/0/0 errors with reason `0 4.11K     0  too many errors`
Given that these bugs are connected to the new test, I understand if you want to hold off on this until I have a fix for those