### PR TITLE
add `status_all(...)` fn to query zpool status with some parameters

### DIFF
--- a/src/zpool/mod.rs
+++ b/src/zpool/mod.rs
@@ -20,6 +20,7 @@ use std::{
     path::PathBuf,
 };
 
+use crate::zpool::open3::StatusOptions;
 use regex::Regex;
 
 pub use self::{
@@ -419,6 +420,9 @@ pub trait ZpoolEngine {
 
     /// Get a status of each active (imported) pool in the system
     fn all(&self) -> ZpoolResult<Vec<Zpool>>;
+
+    /// Query status with options
+    fn status_all(&self, opts: StatusOptions) -> ZpoolResult<Vec<Zpool>>;
 
     /// Begins a scrub or resumes a paused scrub. The scrub examines all data
     /// in the specified pools to verify that it checksums correctly. For

--- a/src/zpool/open3.rs
+++ b/src/zpool/open3.rs
@@ -108,6 +108,16 @@ impl ZpoolOpen3 {
     }
 }
 
+#[derive(Default, Builder, Debug, Clone, Getters)]
+#[builder(setter(into))]
+#[get = "pub"]
+pub struct StatusOptions {
+    #[builder(default)]
+    full_paths: bool,
+    #[builder(default)]
+    resolve_links: bool,
+}
+
 impl ZpoolEngine for ZpoolOpen3 {
     fn exists<N: AsRef<str>>(&self, name: N) -> ZpoolResult<bool> {
         let mut z = self.zpool_mute();
@@ -279,6 +289,20 @@ impl ZpoolEngine for ZpoolOpen3 {
     fn all(&self) -> ZpoolResult<Vec<Zpool>> {
         let mut z = self.zpool();
         z.arg("status");
+        debug!(self.logger, "executing"; "cmd" => format_args!("{:?}", z));
+        let out = z.output()?;
+        self.zpools_from_import(out)
+    }
+
+    fn status_all(&self, opts: StatusOptions) -> ZpoolResult<Vec<Zpool>> {
+        let mut z = self.zpool();
+        z.arg("status");
+        if opts.full_paths {
+            z.arg("-P");
+        }
+        if opts.resolve_links {
+            z.arg("-L");
+        }
         debug!(self.logger, "executing"; "cmd" => format_args!("{:?}", z));
         let out = z.output()?;
         self.zpools_from_import(out)


### PR DESCRIPTION
We'd like to be able to tie back the devices in the zpool status output to other devices on the system. When creating zpools with the entries in `/dev/disk/by-id` or `/dev/disk/by-partuuid` we end up with status output that only includes the relevant id. These options allow us to ask ZFS for exactly what we're looking for.