### PR TITLE
fix `ZpoolOpen3::available()` when a comment is present.

### DIFF
--- a/src/parsers/stdout.pest
+++ b/src/parsers/stdout.pest
@@ -3,7 +3,7 @@ whitespace = _{ " " | "\t" }
 digit = _{ '0'..'9' }
 digits = { digit ~ (digit | "_")* }
 alpha = _{ 'a'..'z' | 'A'..'Z' }
-symbol = _{ "!" | "@" | "," | "." | ";" | ":" | "/" | "\'" | "\"" | "(" | ")" | "-"  | "%" }
+symbol = _{ "!" | "@" | "," | "." | ";" | ":" | "/" | "\'" | "\"" | "(" | ")" | "-"  | "%" | "\\" }
 alpha_num = _{ digit | alpha }
 alpha_nums = _{ alpha_num+ }
 text = _{ (alpha_num | whitespace |symbol)+ }
@@ -21,7 +21,7 @@ status = { whitespace* ~ "status:" ~ multi_line_text }
 action = { whitespace* ~ "action: " ~ multi_line_text }
 see = { whitespace* ~ "see:" ~ whitespace ~ url ~ "\n" }
 config = { whitespace* ~ "config:" ~ "\n" }
-
+comment = { whitespace* ~ "comment: " ~ text? ~ "\n" }
 reason = { text }
 error_statistics = { whitespace* ~ digits ~ whitespace* ~ digits ~ whitespace* ~ digits }
 
@@ -42,7 +42,7 @@ logs = { whitespace* ~ "logs" ~ whitespace* ~ "\n" ~ whitespace* ~ vdevs ~ "\n"?
 caches = { whitespace* ~ "cache" ~ whitespace* ~ "\n" ~ whitespace* ~ disk_line+ ~ "\n"?}
 spares = { whitespace* ~ "spares" ~ whitespace* ~ "\n" ~ whitespace* ~ disk_line+ ~ "\n"?}
 
-zpool = { "\n"? ~ pool_name ~ pool_id? ~ state ~ status? ~ action? ~ see? ~ scan_line? ~ config ~ "\n" ~ pool_headers? ~ pool_line ~  vdevs ~ logs? ~  caches? ~ spares? ~ errors? ~ "\n"?}
+zpool = { "\n"? ~ pool_name ~ pool_id? ~ state ~ status? ~ action? ~ comment? ~ see? ~ scan_line? ~ config ~ "\n" ~ pool_headers? ~ pool_line ~  vdevs ~ logs? ~  caches? ~ spares? ~ errors? ~ "\n"?}
 zpools = _{ zpool*  ~ whitespace* }
 
 text_line = _{ text ~ "\n" }

--- a/src/zpool/description.rs
+++ b/src/zpool/description.rs
@@ -101,7 +101,7 @@ impl Zpool {
                 Rule::spares => {
                     zpool.spares(get_spares_from_pair(pair));
                 }
-                Rule::config | Rule::status | Rule::see | Rule::pool_headers => {}
+                Rule::config | Rule::status | Rule::see | Rule::pool_headers | Rule::comment => {}
                 Rule::scan_line => {}
                 _ => unreachable!(),
             }


### PR DESCRIPTION
Pools with a value in the `comment` field will not show up in the output from `available()`. We observed this when testing with this library, because pools created with this library and then subsequently exported have an empty comment.

Looking at the [ZFS source](https://github.com/openzfs/zfs/blob/baca06c258e07522165cb8e33ff2c0224ad0da57/cmd/zpool/zpool_main.c#L3053) it looks like the `comment:` line comes after the `action:` line.

In testing this I wanted to determine if comment should be a multi-line string or just text. I tried creating and exporting a pool with a `\n` in the comment field and found that the `\n` was reproduced in its escaped form.