### PR TITLE
feat(zpool): Change ZpoolEngine::{status,status_all,all} functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -484,7 +484,7 @@ dependencies = [
 
 [[package]]
 name = "libzetta"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "bitflags",
  "cavity",

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,8 +1,8 @@
-use std::ops::Deref;
 use once_cell::sync::OnceCell;
 use slog::{Drain, Logger as SlogLogger};
 use slog_stdlog::StdLog;
 use std::borrow::Borrow;
+use std::ops::Deref;
 
 static GLOBAL_LOGGER: OnceCell<GlobalLogger> = OnceCell::new();
 

--- a/src/zpool/mod.rs
+++ b/src/zpool/mod.rs
@@ -416,10 +416,7 @@ pub trait ZpoolEngine {
     fn import_from_dir<N: AsRef<str>>(&self, name: N, dir: PathBuf) -> ZpoolResult<()>;
 
     /// Get the detailed status of the given pools.
-    fn status<N: AsRef<str>>(&self, name: N) -> ZpoolResult<Zpool>;
-
-    /// Get a status of each active (imported) pool in the system
-    fn all(&self) -> ZpoolResult<Vec<Zpool>>;
+    fn status<N: AsRef<str>>(&self, name: N, opts: StatusOptions) -> ZpoolResult<Zpool>;
 
     /// Query status with options
     fn status_all(&self, opts: StatusOptions) -> ZpoolResult<Vec<Zpool>>;


### PR DESCRIPTION
 - `all` is removed to avoid being confused with `status_all`.
 - `status` is now taking `StatusOptions` just like `status_all`

BREAKING CHANGE: ZpoolEngine::all removed. ZpoolEngine::status requires
an additional argument.
