### PR TITLE
Pass -p to avoid issues parsing large error counts like '4.11K'

### DIFF
--- a/src/zpool/open3.rs
+++ b/src/zpool/open3.rs
@@ -270,6 +270,7 @@ impl ZpoolEngine for ZpoolOpen3 {
     fn status<N: AsRef<str>>(&self, name: N, opts: StatusOptions) -> ZpoolResult<Zpool> {
         let mut z = self.zpool();
         z.arg("status");
+        z.arg("-p");
         if opts.full_paths {
             z.arg("-P");
         }


### PR DESCRIPTION
For disks with many errors, `zpool status` abbreviates the error counts with things like "4.11k". When this happens, libzetta reports 0 errors for that disk.

To fix this, the `-p` flag makes `zpool status` print the full error count unabbreviated.

I've tested this by `zinject`ing errors into a pool:
```
            wwn-0x5000cca2c...    UNAVAIL  1.78K     0     0  cannot open
```

Before:
```Bash
~$ ./libzetta-repro-orig
ErrorStatistics { read: 0, write: 0, checksum: 0 }
```

After:
```Bash
~$ ./libzetta-repro
ErrorStatistics { read: 1821, write: 0, checksum: 0 }
```