### PR TITLE
fix(zpool): Add support for special vdevs

### DIFF
--- a/src/parsers/stdout.pest
+++ b/src/parsers/stdout.pest
@@ -44,8 +44,9 @@ vdevs = { vdev_line+ }
 logs = { whitespace* ~ "logs" ~ whitespace* ~ "\n" ~ whitespace* ~ vdevs ~ "\n"?}
 caches = { whitespace* ~ "cache" ~ whitespace* ~ "\n" ~ whitespace* ~ disk_line+ ~ "\n"?}
 spares = { whitespace* ~ "spares" ~ whitespace* ~ "\n" ~ whitespace* ~ disk_line+ ~ "\n"?}
+special = { whitespace* ~ "special" ~ whitespace* ~ "\n" ~ whitespace* ~ vdevs ~ "\n"?}
 
-zpool = { "\n"? ~ pool_name ~ pool_id? ~ state ~ status? ~ action? ~ comment? ~ see? ~ scan_line? ~ config ~ "\n" ~ pool_headers? ~ pool_line ~  vdevs ~ logs? ~  caches? ~ spares? ~ errors? ~ "\n"?}
+zpool = { "\n"? ~ pool_name ~ pool_id? ~ state ~ status? ~ action? ~ comment? ~ see? ~ scan_line? ~ config ~ "\n" ~ pool_headers? ~ pool_line ~  vdevs ~ logs? ~  caches? ~ spares? ~ special? ~ errors? ~ "\n"?}
 zpools = _{ zpool*  ~ whitespace* }
 
 text_line = _{ text ~ "\n" }

--- a/src/zpool/description.rs
+++ b/src/zpool/description.rs
@@ -44,7 +44,10 @@ pub struct Zpool {
     /// Spare devices.
     #[builder(default)]
     spares: Vec<Disk>,
-    /// Value of action field what ever it is.
+    /// Special vdevs.
+    #[builder(default)]
+    special: Vec<Vdev>,
+    /// Value of action field whatever it is.
     #[builder(default)]
     action: Option<String>,
     /// Errors?
@@ -100,6 +103,9 @@ impl Zpool {
                 }
                 Rule::spares => {
                     zpool.spares(get_spares_from_pair(pair));
+                }
+                Rule::special => {
+                    zpool.special(get_special_from_pair(pair));
                 }
                 Rule::config | Rule::status | Rule::see | Rule::pool_headers | Rule::comment => {}
                 Rule::scan_line => {}
@@ -329,6 +335,16 @@ fn get_error_from_pair(pair: Pair<'_, Rule>) -> Option<String> {
 #[inline]
 fn get_logs_from_pair(pair: Pair<'_, Rule>) -> Vec<Vdev> {
     debug_assert!(pair.as_rule() == Rule::logs);
+    if let Some(vdevs) = pair.into_inner().next() {
+        get_vdevs_from_pair(vdevs)
+    } else {
+        Vec::new()
+    }
+}
+
+#[inline]
+fn get_special_from_pair(pair: Pair<'_, Rule>) -> Vec<Vdev> {
+    debug_assert!(pair.as_rule() == Rule::special);
     if let Some(vdevs) = pair.into_inner().next() {
         get_vdevs_from_pair(vdevs)
     } else {

--- a/src/zpool/topology.rs
+++ b/src/zpool/topology.rs
@@ -85,6 +85,10 @@ pub struct CreateZpoolRequest {
     /// fails, the hot spare automatically replaces the failed device.
     #[builder(default)]
     spares: Vec<PathBuf>,
+    /// Special vdevs store internal ZFS metadata, deduplication tables, and optionally small blocks as defined by tunables.
+    /// See `zfsconcepts(7)` for more information.
+    #[builder(default)]
+    special: Vec<CreateVdevRequest>,
 }
 
 impl CreateZpoolRequest {


### PR DESCRIPTION
I've added support for special vdevs. The logic is pretty much the same as log devices.

Changes:
- Parse special vdevs
- Test to ensure disks in special vdev are as expected